### PR TITLE
Fix codegen for breaking changes to SymbolProvider

### DIFF
--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/BuilderGenerator.java
@@ -106,7 +106,6 @@ public class BuilderGenerator extends BuilderGeneratorBase {
 
     @Override
     protected void renderUnionBuildMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.build(input, params, context: nil)")
                 .write("case input");
@@ -205,8 +204,8 @@ public class BuilderGenerator extends BuilderGeneratorBase {
          * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexSerializer(Shape shape) {
-            writer.write("$1T.build($2L, params, context: context + $3L + '.') unless $2L.nil?",
-                    symbolProvider.toSymbol(shape), inputGetter, dataName);
+            writer.write("$1L.build($2L, params, context: context + $3L + '.') unless $2L.nil?",
+                    symbolProvider.toSymbol(shape).getName(), inputGetter, dataName);
         }
 
         private void defaultCollectionSerializer(CollectionShape shape) {
@@ -215,8 +214,8 @@ public class BuilderGenerator extends BuilderGeneratorBase {
                 name = "'" + memberShape.getTrait(XmlNameTrait.class).get().getValue() + "'";
             }
             String context = "context + " + name;
-            writer.write("$1T.build($2L, params, context: $3L) unless $2L.nil?",
-                    symbolProvider.toSymbol(shape), inputGetter, context);
+            writer.write("$1L.build($2L, params, context: $3L) unless $2L.nil?",
+                    symbolProvider.toSymbol(shape).getName(), inputGetter, context);
         }
 
         @Override

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/ParserGenerator.java
@@ -338,8 +338,8 @@ public class ParserGenerator extends ParserGeneratorBase {
          * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexDeserializer(Shape shape) {
-            writer.write("$L$T.parse(node)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$L$L.parse(node)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
         }
 
         @Override
@@ -352,8 +352,8 @@ public class ParserGenerator extends ParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('$L')", xmlName);
             }
-            writer.write("$L$T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$L$L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 
@@ -362,8 +362,8 @@ public class ParserGenerator extends ParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('entry')");
             }
-            writer.write("$L$T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$L$L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/ec2/generators/StubsGenerator.java
@@ -78,7 +78,6 @@ public class StubsGenerator extends StubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(node_name, stub = {})")
                 .write("xml = $T.new(node_name)", Hearth.XML_NODE)
@@ -286,8 +285,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                 XmlNamespaceTrait xmlns = memberShape.expectTrait(XmlNamespaceTrait.class);
                 writer
                         .openBlock("unless $L.nil?", inputGetter)
-                        .write("nodes = $1T.stub($2L, $3L)",
-                                symbolProvider.toSymbol(shape),
+                        .write("nodes = $1L.stub($2L, $3L)",
+                                symbolProvider.toSymbol(shape).getName(),
                                 nodeName,
                                 inputGetter)
                         .write("nodes.each { |n| n.attributes['xmlns$1L'] = '$2L' }",
@@ -296,8 +295,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                         .write("xml << nodes")
                         .closeBlock("end");
             } else {
-                writer.write("xml << $1T.stub($2L, $3L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName, inputGetter);
+                writer.write("xml << $1L.stub($2L, $3L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName, inputGetter);
             }
         }
 
@@ -310,8 +309,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                 if (shape.getMember().hasTrait(XmlNameTrait.class)) {
                     memberName = shape.getMember().getTrait(XmlNameTrait.class).get().getValue();
                 }
-                writer.write("xml << $6T::Node.new($2L, $1T.stub('$4L', $3L)$5L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $6T::Node.new($2L, $1L.stub('$4L', $3L)$5L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, memberName, xmlnsAttribute(), Hearth.XML);
             }
             return null;
@@ -322,8 +321,8 @@ public class StubsGenerator extends StubsGeneratorBase {
             if (memberShape.hasTrait(XmlFlattenedTrait.class) || shape.hasTrait(XmlFlattenedTrait.class)) {
                 defaultComplexSerializer(shape);
             } else {
-                writer.write("xml << $5T::Node.new($2L, $1T.stub('entry', $3L)$4L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $5T::Node.new($2L, $1L.stub('entry', $3L)$4L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, xmlnsAttribute(), Hearth.XML);
             }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/BuilderGenerator.java
@@ -105,7 +105,6 @@ public class BuilderGenerator extends BuilderGeneratorBase {
 
     @Override
     protected void renderUnionBuildMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.build(input)")
                 .write("data = {}")
@@ -220,12 +219,12 @@ public class BuilderGenerator extends BuilderGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.build($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.build($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             } else {
-                writer.write("$1L($2T.build($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.build($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             }
         }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/ParserGenerator.java
@@ -240,12 +240,12 @@ public class ParserGenerator extends ParserGeneratorBase {
          */
         private void defaultComplexDeserializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.parse($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.parse($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             } else {
-                writer.write("$1L($2T.parse($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.parse($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             }
         }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json/generators/StubsGenerator.java
@@ -47,7 +47,6 @@ public class StubsGenerator extends StubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(stub)")
                 .write("data = {}")
@@ -222,11 +221,11 @@ public class StubsGenerator extends StubsGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.stub($3L) unless $3L.nil?", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L$2L.stub($3L) unless $3L.nil?", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             } else {
-                writer.write("$1L($2T.stub($3L) unless $3L.nil?)", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L($2L.stub($3L) unless $3L.nil?)", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             }
         }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/BuilderGenerator.java
@@ -94,7 +94,6 @@ public class BuilderGenerator extends BuilderGeneratorBase {
 
     @Override
     protected void renderUnionBuildMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.build(input)")
                 .write("data = {}")
@@ -209,12 +208,12 @@ public class BuilderGenerator extends BuilderGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.build($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.build($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             } else {
-                writer.write("$1L($2T.build($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.build($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             }
         }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/ParserGenerator.java
@@ -230,12 +230,12 @@ public class ParserGenerator extends ParserGeneratorBase {
          */
         private void defaultComplexDeserializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.parse($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.parse($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             } else {
-                writer.write("$1L($2T.parse($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.parse($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             }
         }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/json10/generators/StubsGenerator.java
@@ -47,7 +47,6 @@ public class StubsGenerator extends StubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(stub)")
                 .write("data = {}")
@@ -221,11 +220,11 @@ public class StubsGenerator extends StubsGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.stub($3L) unless $3L.nil?", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L$2L.stub($3L) unless $3L.nil?", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             } else {
-                writer.write("$1L($2T.stub($3L) unless $3L.nil?)", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L($2L.stub($3L) unless $3L.nil?)", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             }
         }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/BuilderGenerator.java
@@ -94,7 +94,6 @@ public class BuilderGenerator extends BuilderGeneratorBase {
 
     @Override
     protected void renderUnionBuildMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.build(input, params, context: nil)")
                 .write("case input");
@@ -215,8 +214,8 @@ public class BuilderGenerator extends BuilderGeneratorBase {
          * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexSerializer(Shape shape) {
-            writer.write("$1T.build($2L, params, context: context + $3L + '.') unless $2L.nil?",
-                    symbolProvider.toSymbol(shape), inputGetter, dataName);
+            writer.write("$1L.build($2L, params, context: context + $3L + '.') unless $2L.nil?",
+                    symbolProvider.toSymbol(shape).getName(), inputGetter, dataName);
         }
 
         private void defaultCollectionSerializer(CollectionShape shape) {
@@ -232,8 +231,8 @@ public class BuilderGenerator extends BuilderGeneratorBase {
                 }
                 context += " + '." + member + "'";
             }
-            writer.write("$1T.build($2L, params, context: $3L) unless $2L.nil?",
-                    symbolProvider.toSymbol(shape), inputGetter, context);
+            writer.write("$1L.build($2L, params, context: $3L) unless $2L.nil?",
+                    symbolProvider.toSymbol(shape).getName(), inputGetter, context);
         }
 
         @Override
@@ -252,8 +251,8 @@ public class BuilderGenerator extends BuilderGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 context += " + '.entry'";
             }
-            writer.write("$1T.build($2L, params, context: $3L) unless $2L.nil?",
-                    symbolProvider.toSymbol(shape), inputGetter, context);
+            writer.write("$1L.build($2L, params, context: $3L) unless $2L.nil?",
+                    symbolProvider.toSymbol(shape).getName(), inputGetter, context);
             return null;
         }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/ParserGenerator.java
@@ -339,8 +339,8 @@ public class ParserGenerator extends ParserGeneratorBase {
          * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexDeserializer(Shape shape) {
-            writer.write("$1L$2T.parse(node)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(node)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
         }
 
         @Override
@@ -353,8 +353,8 @@ public class ParserGenerator extends ParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('$L')", xmlName);
             }
-            writer.write("$1L$2T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 
@@ -363,8 +363,8 @@ public class ParserGenerator extends ParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('entry')");
             }
-            writer.write("$1L$2T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/query/generators/StubsGenerator.java
@@ -78,7 +78,6 @@ public class StubsGenerator extends StubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(node_name, stub)")
                 .write("xml = $T.new(node_name)", Hearth.XML_NODE)
@@ -288,8 +287,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                 XmlNamespaceTrait xmlns = memberShape.expectTrait(XmlNamespaceTrait.class);
                 writer
                         .openBlock("unless $L.nil?", inputGetter)
-                        .write("nodes = $1T.stub($2L, $3L)",
-                                symbolProvider.toSymbol(shape),
+                        .write("nodes = $1L.stub($2L, $3L)",
+                                symbolProvider.toSymbol(shape).getName(),
                                 nodeName,
                                 inputGetter)
                         .write("nodes.each { |n| n.attributes['xmlns$1L'] = '$2L' }",
@@ -298,8 +297,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                         .write("xml << nodes")
                         .closeBlock("end");
             } else {
-                writer.write("xml << $1T.stub($2L, $3L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $1L.stub($2L, $3L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter);
             }
         }
@@ -313,8 +312,8 @@ public class StubsGenerator extends StubsGeneratorBase {
                 if (shape.getMember().hasTrait(XmlNameTrait.class)) {
                     memberName = shape.getMember().getTrait(XmlNameTrait.class).get().getValue();
                 }
-                writer.write("xml << $6T.new($2L, $1T.stub('$4L', $3L)$5L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $6T.new($2L, $1L.stub('$4L', $3L)$5L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, memberName, xmlnsAttribute(), Hearth.XML_NODE);
             }
             return null;
@@ -325,8 +324,8 @@ public class StubsGenerator extends StubsGeneratorBase {
             if (memberShape.hasTrait(XmlFlattenedTrait.class) || shape.hasTrait(XmlFlattenedTrait.class)) {
                 defaultComplexSerializer(shape);
             } else {
-                writer.write("xml << $5T.new($2L, $1T.stub('entry', $3L)$4L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $5T.new($2L, $1L.stub('entry', $3L)$4L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, xmlnsAttribute(), Hearth.XML_NODE);
             }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/BuilderGenerator.java
@@ -227,12 +227,12 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.build($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.build($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             } else {
-                writer.write("$1L($2T.build($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.build($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         inputGetter);
             }
         }
@@ -336,7 +336,7 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
             writer
                     .write("http_req.headers['Content-Type'] = 'application/json'")
                     .write("data = {}")
-                    .write("data = $1T.build($2L) unless $2L.nil?", symbolProvider.toSymbol(shape),
+                    .write("data = $1L.build($2L) unless $2L.nil?", symbolProvider.toSymbol(shape).getName(),
                             inputGetter)
                     .write("http_req.body = $T.new($T.dump(data))", RubyImportContainer.STRING_IO, Hearth.JSON);
         }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/ParserGenerator.java
@@ -231,12 +231,12 @@ public class ParserGenerator extends RestParserGeneratorBase {
          */
         private void defaultComplexDeserializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.parse($3L) unless $3L.nil?",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L$2L.parse($3L) unless $3L.nil?",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             } else {
-                writer.write("$1L($2T.parse($3L) unless $3L.nil?)",
-                        dataSetter, symbolProvider.toSymbol(shape),
+                writer.write("$1L($2L.parse($3L) unless $3L.nil?)",
+                        dataSetter, symbolProvider.toSymbol(shape).getName(),
                         jsonGetter);
             }
         }
@@ -332,7 +332,7 @@ public class ParserGenerator extends RestParserGeneratorBase {
         private void defaultComplexDeserializer(Shape shape) {
             writer
                     .write("json = $T.load(http_resp.body)", Hearth.JSON)
-                    .write("$L$T.parse(json)", dataSetter, symbolProvider.toSymbol(shape));
+                    .write("$L$L.parse(json)", dataSetter, symbolProvider.toSymbol(shape).getName());
         }
 
     }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restjson/generators/StubsGenerator.java
@@ -106,7 +106,6 @@ public class StubsGenerator extends RestStubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(stub)")
                 .write("data = {}")
@@ -241,11 +240,11 @@ public class StubsGenerator extends RestStubsGeneratorBase {
          */
         private void defaultComplexSerializer(Shape shape) {
             if (checkRequired) {
-                writer.write("$1L$2T.stub($3L) unless $3L.nil?", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L$2L.stub($3L) unless $3L.nil?", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             } else {
-                writer.write("$1L($2T.stub($3L) unless $3L.nil?)", dataSetter,
-                        symbolProvider.toSymbol(shape), inputGetter);
+                writer.write("$1L($2L.stub($3L) unless $3L.nil?)", dataSetter,
+                        symbolProvider.toSymbol(shape).getName(), inputGetter);
             }
         }
 
@@ -347,7 +346,7 @@ public class StubsGenerator extends RestStubsGeneratorBase {
         private void defaultComplexSerializer(Shape shape) {
             writer
                     .write("http_resp.headers['Content-Type'] = 'application/json'")
-                    .write("data = $1T.stub($2L) unless $2L.nil?", symbolProvider.toSymbol(shape),
+                    .write("data = $1L.stub($2L) unless $2L.nil?", symbolProvider.toSymbol(shape).getName(),
                             inputGetter)
                     .write("http_resp.body = $T.new($T.dump(data))",
                             RubyImportContainer.STRING_IO, Hearth.JSON);

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/BuilderGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/BuilderGenerator.java
@@ -131,7 +131,6 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
 
     @Override
     protected void renderUnionBuildMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.build(node_name, input)")
                 .write("xml = $T.new(node_name)", Hearth.XML_NODE)
@@ -291,8 +290,8 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
                 XmlNamespaceTrait xmlns = memberShape.expectTrait(XmlNamespaceTrait.class);
                 writer
                         .openBlock("unless $L.nil?", inputGetter)
-                        .write("nodes = $1T.build($2L, $3L)",
-                                symbolProvider.toSymbol(shape),
+                        .write("nodes = $1L.build($2L, $3L)",
+                                symbolProvider.toSymbol(shape).getName(),
                                 nodeName,
                                 inputGetter)
                         .write("nodes.each { |n| n.attributes['xmlns$1L'] = '$2L' }",
@@ -301,8 +300,8 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
                         .write("xml << nodes")
                         .closeBlock("end");
             } else {
-                writer.write("xml << $1T.build($2L, $3L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName, inputGetter);
+                writer.write("xml << $1L.build($2L, $3L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName, inputGetter);
             }
         }
 
@@ -315,8 +314,8 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
                 if (shape.getMember().hasTrait(XmlNameTrait.class)) {
                     memberName = shape.getMember().getTrait(XmlNameTrait.class).get().getValue();
                 }
-                writer.write("xml << $6T.new($2L, $1T.build('$4L', $3L)$5L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $6T.new($2L, $1L.build('$4L', $3L)$5L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, memberName, xmlnsAttribute(), Hearth.XML_NODE);
             }
             return null;
@@ -327,8 +326,8 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
             if (memberShape.hasTrait(XmlFlattenedTrait.class) || shape.hasTrait(XmlFlattenedTrait.class)) {
                 defaultComplexSerializer(shape);
             } else {
-                writer.write("xml << $5T.new($2L, $1T.build('entry', $3L)$4L) unless $3L.nil?",
-                        symbolProvider.toSymbol(shape), nodeName,
+                writer.write("xml << $5T.new($2L, $1L.build('entry', $3L)$4L) unless $3L.nil?",
+                        symbolProvider.toSymbol(shape).getName(), nodeName,
                         inputGetter, xmlnsAttribute(), Hearth.XML_NODE);
             }
 

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/ParserGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/ParserGenerator.java
@@ -367,8 +367,8 @@ public class ParserGenerator extends RestParserGeneratorBase {
          * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexDeserializer(Shape shape) {
-            writer.write("$1L$2T.parse(node)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(node)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
         }
 
         @Override
@@ -381,8 +381,8 @@ public class ParserGenerator extends RestParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('$L')", xmlName);
             }
-            writer.write("$1L$2T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 
@@ -391,8 +391,8 @@ public class ParserGenerator extends RestParserGeneratorBase {
             if (!memberShape.hasTrait(XmlFlattenedTrait.class)) {
                 writer.write("children = node.children('entry')");
             }
-            writer.write("$1L$2T.parse(children)",
-                    dataSetter, symbolProvider.toSymbol(shape));
+            writer.write("$1L$2L.parse(children)",
+                    dataSetter, symbolProvider.toSymbol(shape).getName());
             return null;
         }
 
@@ -469,7 +469,7 @@ public class ParserGenerator extends RestParserGeneratorBase {
                     .write("body = http_resp.body.read")
                     .write("return data if body.empty?")
                     .write("xml = $T.parse(body)", Hearth.XML)
-                    .write("$L$T.parse(xml)", dataSetter, symbolProvider.toSymbol(shape));
+                    .write("$L$L.parse(xml)", dataSetter, symbolProvider.toSymbol(shape).getName());
         }
 
     }

--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/StubsGenerator.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/protocol/restxml/generators/StubsGenerator.java
@@ -164,7 +164,6 @@ public class StubsGenerator extends RestStubsGeneratorBase {
 
     @Override
     protected void renderUnionStubMethod(UnionShape shape) {
-        Symbol symbol = symbolProvider.toSymbol(shape);
         writer
                 .openBlock("def self.stub(node_name, stub)")
                 .write("xml = $T.new(node_name)", Hearth.XML_NODE)


### PR DESCRIPTION

*Description of changes:*
Fixes codegen issues introduced by breaking changes made to SymbolProvider in: https://github.com/awslabs/smithy-ruby/pull/113/

This PR fixes ONLY those issues.  Protocol tests still do not fully pass, but number of failing reduced from ~80 per protocol to about 4 or 5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
