### PR TITLE
Fix bug in includeFor + add truncate to body wrappers

### DIFF
--- a/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/HttpChecksum.java
+++ b/codegen/smithy-aws-ruby-codegen/src/main/java/software/amazon/smithy/aws/ruby/codegen/HttpChecksum.java
@@ -3,6 +3,8 @@ package software.amazon.smithy.aws.ruby.codegen;
 import software.amazon.smithy.aws.traits.HttpChecksumTrait;
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
@@ -14,12 +16,15 @@ import software.amazon.smithy.ruby.codegen.util.Streaming;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public class HttpChecksum implements RubyIntegration {
     @Override
     public boolean includeFor(ServiceShape service, Model model) {
-        return model.isTraitApplied(HttpChecksumTrait.class);
+        return TopDownIndex.of(model).getContainedOperations(service).stream()
+                .anyMatch( (o) -> o.hasTrait(HttpChecksumTrait.class));
     }
 
     @Override

--- a/gems/aws-sdk-core/lib/aws-sdk-core/middleware/checksums.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/middleware/checksums.rb
@@ -216,6 +216,10 @@ module AWS::SDK::Core
           @io.rewind
         end
 
+        def truncate(len)
+          @io.truncate(len) if @io.respond_to?(:truncate)
+        end
+
         def size
           @io.size
         end
@@ -264,6 +268,10 @@ module AWS::SDK::Core
 
         def rewind
           @io.rewind
+        end
+
+        def truncate(len)
+          @io.truncate(len) if @io.respond_to?(:truncate)
         end
 
         def read(length = CHUNK_SIZE, buf = nil)


### PR DESCRIPTION

*Description of changes:*
The model passed to `includeFor` has all models (not filtered to service) - fix: get the contained operations in the service.

Adds `truncate` methods to digest IO wrappers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
