### PR TITLE
fix sigv4a signing issue with derive_asymmetric_key

### DIFF
--- a/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
@@ -65,12 +65,13 @@ module AWS
         x
       end
 
-      # @return [Array] value of the BigNumber as a big-endian unsigned byte array.
-      def self.bn_to_be_bytes(bn)
+      # @return [Array] value of the BigNumber as a big-endian
+      # unsigned byte array.
+      def self.bn_to_be_bytes(value)
         bytes = []
-        while bn > 0
-          bytes << (bn & 0xff)
-          bn = bn >> 8
+        while value.positive?
+          bytes << (value & 0xff)
+          value >>= 8
         end
         bytes.reverse
       end
@@ -84,7 +85,7 @@ module AWS
         asn1 = OpenSSL::ASN1::Sequence(
           [
             OpenSSL::ASN1::Integer(OpenSSL::BN.new(1)),
-            OpenSSL::ASN1::OctetString(bn_to_be_bytes(d).pack('C*')),
+            OpenSSL::ASN1::OctetString(bn_to_be_bytes(private_key).pack('C*')),
             OpenSSL::ASN1::ASN1Data.new(
               [OpenSSL::ASN1::ObjectId('prime256v1')],
               0, :CONTEXT_SPECIFIC

--- a/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
@@ -65,6 +65,16 @@ module AWS
         x
       end
 
+      # @return [Array] value of the BigNumber as a big-endian unsigned byte array.
+      def self.bn_to_be_bytes(bn)
+        bytes = []
+        while bn > 0
+          bytes << (bn & 0xff)
+          bn = bn >> 8
+        end
+        bytes.reverse
+      end
+
       # Prior to openssl3 we could directly set public and private key on EC
       # However, openssl3 deprecated those methods and we must now construct
       # a der with the keys and load the EC from it.
@@ -74,7 +84,7 @@ module AWS
         asn1 = OpenSSL::ASN1::Sequence(
           [
             OpenSSL::ASN1::Integer(OpenSSL::BN.new(1)),
-            OpenSSL::ASN1::OctetString([private_key.to_s(16)].pack('H*')),
+            OpenSSL::ASN1::OctetString(bn_to_be_bytes(d).pack('C*')),
             OpenSSL::ASN1::ASN1Data.new(
               [OpenSSL::ASN1::ObjectId('prime256v1')],
               0, :CONTEXT_SPECIFIC

--- a/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
+++ b/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
@@ -44,6 +44,19 @@ module AWS
             0x865ED22A7EADC9C5CB9D2CBACA1B3699139FEDC5043DC6661864218330C8E518
           )
         end
+
+        # ensure that encoding of private keys with MSB set result in valid EC objects
+        context 'private key with most significant bit set' do
+
+          let(:access_key_id) { 'ASIAZRFOHJT45NGNWXS3' }
+          let(:secret_access_key) { 'WOuDKprKr+rt3Dl7+RCiNpZGzi3Jw/DdVifyifuC' }
+          let(:test_value) { 'test_value' }
+
+          it 'derives a valid EC PKey' do
+            signature = ec.dsa_sign_asn1(test_value)
+            expect(ec.dsa_verify_asn1(test_value, signature)).to be_truthy
+          end
+        end
       end
     end
   end

--- a/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
+++ b/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
@@ -45,9 +45,9 @@ module AWS
           )
         end
 
-        # ensure that encoding of private keys with MSB set result in valid EC objects
+        # ensure that encoding of private keys with MSB set result in
+        # valid EC objects
         context 'private key with most significant bit set' do
-
           let(:access_key_id) { 'ASIAZRFOHJT45NGNWXS3' }
           let(:secret_access_key) { 'WOuDKprKr+rt3Dl7+RCiNpZGzi3Jw/DdVifyifuC' }
           let(:test_value) { 'test_value' }

--- a/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
+++ b/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
@@ -48,8 +48,8 @@ module AWS
         # ensure that encoding of private keys with MSB set result in
         # valid EC objects
         context 'private key with most significant bit set' do
-          let(:access_key_id) { 'ASIAZRFOHJT45NGNWXS3' }
-          let(:secret_access_key) { 'WOuDKprKr+rt3Dl7+RCiNpZGzi3Jw/DdVifyifuC' }
+          let(:access_key_id) { 'ASIAJOP4OINN7EXAMPLE' }
+          let(:secret_access_key) { 'bJalbXutNFeni/k7MDEnG/byxRfiCYEXAMPLEKEY' }
           let(:test_value) { 'test_value' }
 
           it 'derives a valid EC PKey' do


### PR DESCRIPTION

*Description of changes:*
See V3 fix:  https://github.com/aws/aws-sdk-ruby/pull/3129


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
